### PR TITLE
Allow all traffic in robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
Perhaps this will enable Google's bots to scrape our site, because right now Google neither accepts the privacy policy published on the website, nor will Google Ads link to any page except the landing page.