### PR TITLE
Fix lint warning: <ul> cannot be child of <p>

### DIFF
--- a/src/home/Home.vue
+++ b/src/home/Home.vue
@@ -2,9 +2,7 @@
   <main-layout>
     <div class="content">
       <div class="topSection">
-        <a
-          href="/fist"
-        >
+        <a href="/fist">
           <img
             alt="Sound Realms Kickstarter"
             class="topImage"
@@ -17,21 +15,38 @@
           <h1>THE Audio Adventure System</h1>
           <div class="text">
             <p>
-              Step into a world where <strong>every choice you make shapes the story</strong>, and every twist comes alive in breathtaking audio detail. Sound Realms isn't just any role-playing game, it's an immersive audio experience that puts <strong>you</strong> in the center of an epic adventure!
+              Step into a world where <strong>every choice you make shapes the story</strong>, and
+              every twist comes alive in breathtaking audio detail. Sound Realms isn't just any
+              role-playing game, it's an immersive audio experience that puts
+              <strong>you</strong> in the center of an epic adventure!
             </p>
             <p>
-              With <strong>professional voice actors narrating every scene</strong>, prepare to feel the intensity and depth of a real, cinematic audio adventure. The high-quality <strong>360° surround sound wraps you in a world of captivating soundscapes</strong>: from the whisper of leaves in an ancient forest to the thunderous clash of battle, each effect and musical score pulls you deeper into the narrative. It's like being inside your favorite fantasy, sci-fi or horror movie, only this time, <strong>you are the hero</strong>.
+              With <strong>professional voice actors narrating every scene</strong>, prepare to feel
+              the intensity and depth of a real, cinematic audio adventure. The high-quality
+              <strong>360° surround sound wraps you in a world of captivating soundscapes</strong>:
+              from the whisper of leaves in an ancient forest to the thunderous clash of battle,
+              each effect and musical score pulls you deeper into the narrative. It's like being
+              inside your favorite fantasy, sci-fi or horror movie, only this time,
+              <strong>you are the hero</strong>.
             </p>
+            <p>Highlights:</p>
+            <ul>
+              <li>
+                🎙️ <strong>Narration by Top Voice Talent</strong>: Feel each line delivered with
+                emotion, character, and impact.
+              </li>
+              <li>
+                🎶 <strong>Soundtrack & Cinematic Effects</strong>: Masterfully crafted music and
+                sound effects heighten every scene.
+              </li>
+              <li>
+                🎧 <strong>Immersive 360° Surround Sound</strong>: Designed to make you feel like
+                you're truly there, no matter where your adventure takes you.
+              </li>
+            </ul>
             <p>
-              Highlights:
-              <ul>
-                <li>🎙️ <strong>Narration by Top Voice Talent</strong>: Feel each line delivered with emotion, character, and impact.</li>
-                <li>🎶 <strong>Soundtrack & Cinematic Effects</strong>: Masterfully crafted music and sound effects heighten every scene.</li>
-                <li>🎧 <strong>Immersive 360° Surround Sound</strong>: Designed to make you feel like you're truly there, no matter where your adventure takes you.</li>
-              </ul>
-            </p>
-            <p>
-              Whether you're braving mythical lands or solving mysterious quests, every listen brings a new layer to your personal adventure.
+              Whether you're braving mythical lands or solving mysterious quests, every listen
+              brings a new layer to your personal adventure.
             </p>
             <p>
               <strong>Download today and try for free. Let your story unfold!</strong>


### PR DESCRIPTION
This solves the following lint warning:

    [vite] warning: <ul> cannot be child of <p>, according to HTML specifications. 
    This can cause hydration errors or potentially disrupt future functionality.