### PR TITLE
Update the website README and restore a clean lint pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ The live version runs on Node v. 20 – this is configurable on [Netlify](https:
 npm ci
 ```
 
-### Compiles and hot-reloads for development
+### Start the local development server
 ```
-npm run serve
+npm run dev
 ```
 
-### Compiles and minifies for production
+### Build for production
 ```
 npm run build
 ```
 
-### Run your tests
+The build writes the site to `dist/` and copies `dist/index.html` to `dist/404.html` for Netlify SPA routing.
+
+### Lint the source tree
 ```
-npm run test
+npm run lint
 ```
 
-### Lints and fixes files
-```
-npm run lint --fix
-```
+### Test status
+This repo does not currently ship an automated test script. Validation is currently limited to linting and production builds until a test harness is added.

--- a/src/presskit/Dracula.vue
+++ b/src/presskit/Dracula.vue
@@ -135,6 +135,7 @@ import MyButton from "../components/MyButton.vue";
 import MyBreadcrumbs from "../components/MyBreadcrumbs.vue";
 
 export default {
+  name: "DraculaPress",
   components: {
     MainLayout,
     MainFooter,


### PR DESCRIPTION
## Summary
- update the README so its documented commands match the actual Vite scripts in this repo
- document that the repo currently has no automated test script, so validation is lint + build today
- give the `src/presskit/Dracula.vue` component a multi-word name so `npm run lint` no longer fails on the default branch

## Validation
- npm run lint
- npm run build

Related to #114
Related to #115