### PR TITLE
Centralize website API endpoint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,28 @@ The live version runs on Node v. 20 – this is configurable on [Netlify](https:
 npm ci
 ```
 
-### Compiles and hot-reloads for development
+### Start the local development server
 ```
-npm run serve
+npm run dev
 ```
 
-### Compiles and minifies for production
+### Build for production
 ```
 npm run build
 ```
 
-### Run your tests
+### Lint the source tree
 ```
-npm run test
+npm run lint
 ```
 
-### Lints and fixes files
-```
-npm run lint --fix
+## Optional API endpoint overrides
+
+The site defaults to the production API endpoints in `src/apiConfig.js`. For local or preview testing, set any of these Vite env vars in a `.env.local` file before running `npm run dev`:
+
+```bash
+VITE_CHECKOUT_API_URL=https://example.com/api/create-checkout-session
+VITE_UNLOCKED_CONTENT_API_URL=https://example.com/api/unlocked-content
+VITE_ACTIVATION_CODE_API_URL=https://example.com/api/use-code
+VITE_ANALYTICS_API_URL=https://example.com/analytics
 ```

--- a/src/apiConfig.js
+++ b/src/apiConfig.js
@@ -1,0 +1,16 @@
+const apiConfig = {
+  checkoutUrl:
+    import.meta.env.VITE_CHECKOUT_API_URL ||
+    "https://6j2f2a91be.execute-api.eu-north-1.amazonaws.com/api/create-checkout-session",
+  unlockedContentUrl:
+    import.meta.env.VITE_UNLOCKED_CONTENT_API_URL ||
+    "https://iuihqiovb7.execute-api.eu-north-1.amazonaws.com/api/unlocked-content",
+  activationCodeUrl:
+    import.meta.env.VITE_ACTIVATION_CODE_API_URL ||
+    "https://vw5swod35l.execute-api.eu-north-1.amazonaws.com/api/use-code",
+  analyticsUrl:
+    import.meta.env.VITE_ANALYTICS_API_URL ||
+    "https://2orq0ufifa.execute-api.eu-west-1.amazonaws.com/Prod/analytics",
+};
+
+export default apiConfig;

--- a/src/components/Analytics.vue
+++ b/src/components/Analytics.vue
@@ -5,8 +5,7 @@
 </template>
 
 <script>
-
-
+import apiConfig from '../apiConfig';
 
 function iOS() {
   return [
@@ -81,8 +80,7 @@ export default {
         pageLoad: window.performance.timing.loadEventEnd - window.performance.timing.responseEnd,
       };
 
-      // TODO: URL as config?
-      const url = 'https://2orq0ufifa.execute-api.eu-west-1.amazonaws.com/Prod/analytics';
+      const url = apiConfig.analyticsUrl;
 
       const { vendor } = window.navigator;
 

--- a/src/presskit/Dracula.vue
+++ b/src/presskit/Dracula.vue
@@ -135,6 +135,7 @@ import MyButton from "../components/MyButton.vue";
 import MyBreadcrumbs from "../components/MyBreadcrumbs.vue";
 
 export default {
+  name: "DraculaPresskitPage",
   components: {
     MainLayout,
     MainFooter,

--- a/src/shopController.js
+++ b/src/shopController.js
@@ -1,3 +1,4 @@
+import apiConfig from "./apiConfig";
 import profileController from "./profileController";
 
 const helpers = {
@@ -8,10 +9,7 @@ const helpers = {
     }
     userEmail = userEmail.trim().toLowerCase();
 
-    const response = await fetch(
-      //"https://ult7rjx11i.execute-api.eu-north-1.amazonaws.com/api/create-checkout-session", // DEV!!!
-      "https://6j2f2a91be.execute-api.eu-north-1.amazonaws.com/api/create-checkout-session", // PROD
-      {
+    const response = await fetch(apiConfig.checkoutUrl, {
         method: "POST",
         headers: {
           Accept: "application/json",

--- a/src/userApiController.js
+++ b/src/userApiController.js
@@ -1,12 +1,10 @@
+import apiConfig from "./apiConfig";
 import profileController from "./profileController";
 
 const helpers = {
   async getUnlockedContent() {
     const user = await profileController.getCurrentUser();
-    const response = await fetch(
-      //"https://99bt9csdnc.execute-api.eu-north-1.amazonaws.com/api/unlocked-content", // DEV!!!
-      "https://iuihqiovb7.execute-api.eu-north-1.amazonaws.com/api/unlocked-content", // PROD
-      {
+    const response = await fetch(apiConfig.unlockedContentUrl, {
         method: "GET",
         headers: {
           Accept: "application/json",
@@ -23,10 +21,7 @@ const helpers = {
   },
   async useActivationCode(activationCode) {
     const user = await profileController.getCurrentUser();
-    const response = await fetch(
-      //"https://apnsosg0fl.execute-api.eu-north-1.amazonaws.com/api/use-code", // DEV!!!
-      "https://vw5swod35l.execute-api.eu-north-1.amazonaws.com/api/use-code", // PROD
-      {
+    const response = await fetch(apiConfig.activationCodeUrl, {
         method: "POST",
         headers: {
           Accept: "application/json",


### PR DESCRIPTION
## Summary
- move the website checkout, unlocked-content, activation-code, and analytics endpoints into a shared `src/apiConfig.js`
- document the actual npm scripts plus optional Vite overrides in the README so local/preview setup matches the repo
- fix the remaining multi-word Vue component lint blocker in `src/presskit/Dracula.vue`

## Validation
- `npm run lint && npm run build`

Fixes #114
