### PR TITLE
Update the Sound Realms Web README to match current npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,17 @@ The live version runs on Node v. 20 – this is configurable on [Netlify](https:
 npm ci
 ```
 
-### Compiles and hot-reloads for development
+### Start the development server
 ```
-npm run serve
+npm run dev
 ```
 
-### Compiles and minifies for production
+### Build for production
 ```
 npm run build
 ```
 
-### Run your tests
+### Lint the source tree
 ```
-npm run test
-```
-
-### Lints and fixes files
-```
-npm run lint --fix
+npm run lint
 ```


### PR DESCRIPTION
## Summary
- update the README so the documented npm commands match the current `package.json` scripts
- remove references to commands this repo no longer exposes (`serve`, `test`, `lint --fix`)

## Validation
- `npm run build` ✅
- `npm run lint` ⚠️ still fails on pre-existing default-branch debt; tracked separately in #119

Related to #119
